### PR TITLE
Consistent txt style

### DIFF
--- a/src/Output.f90
+++ b/src/Output.f90
@@ -532,10 +532,14 @@ contains
       inquire (file=filename%s, exist=FileExists)
       if ((.not.FileExists).or.(create_new)) then
          open (101, file=filename%s, status='replace')
-         write(101,fmt="(a12,a2,6(a24,a2))") '        time', ', ', &
-           '                  volume', ', ', '        total bed volume', ', ', &
-           '              total mass', ', ', '                bed mass', ', ', &
-           '       total solids mass', ', ', '         bed solids mass', ', '
+         write(101,fmt="(a12,6(a2,a24))") &
+            '        time', ', ', &
+            '                  volume', ', ', &
+            '        total_bed_volume', ', ', &
+            '              total_mass', ', ', &
+            '                bed_mass', ', ', &
+            '       total_solids_mass', ', ', &
+            '         bed_solids_mass'
       else
          open (101, file=filename%s, status="old", position="append")
       end if
@@ -590,7 +594,14 @@ contains
 
       ! Write out
       ! t, volume, total mass, total bed mass, total solid mass, total bed solid mass
-      write(101,fmt="(f12.2,a2,6(es24.15,a2))") t, ', ', vol, ', ', bed, ', ', mass, ', ', bed * rhob, ', ', solids * rhos, ', ', bed * rhos * (1.0_wp - RunParams%BedPorosity), ', '
+      write(101,fmt="(f12.2,6(a2, es24.15))") &
+         t, ', ', &
+         vol, ', ', &
+         bed, ', ', &
+         mass, ', ', &
+         bed * rhob, ', ', &
+         solids * rhos, ', ', &
+         bed * rhos * (1.0_wp - RunParams%BedPorosity)
 
       close (101)
 

--- a/tests/testlib.jl
+++ b/tests/testlib.jl
@@ -119,17 +119,17 @@ function check_conservativity(dir)
    # ways to do this but they require libraries so less portable.
    #
    # Flow volumes (at start/end of simulation)
-   vol_t0 = parse(Float64, replace.(readchomp(`awk 'NR==2 {print $2}' $vfile`), [','] => ""))
-   vol_tn = parse(Float64, replace.(readchomp(`awk 'END {print $2}' $vfile`), [','] => ""))
+   vol_t0 = parse(Float64, replace(readchomp(`awk 'NR==2 {print $2}' $vfile`), [','] => ""))
+   vol_tn = parse(Float64, replace(readchomp(`awk 'END {print $2}' $vfile`), [','] => ""))
    # Bed volumes
-   b_t0 = parse(Float64, replace.(readchomp(`awk 'NR==2 {print $3}' $vfile`), [','] => ""))
-   b_tn = parse(Float64, replace.(readchomp(`awk 'END {print $3}' $vfile`), [','] => ""))
+   b_t0 = parse(Float64, replace(readchomp(`awk 'NR==2 {print $3}' $vfile`), [','] => ""))
+   b_tn = parse(Float64, replace(readchomp(`awk 'END {print $3}' $vfile`), [','] => ""))
    # Solids masses
-   solm_t0 = parse(Float64, replace.(readchomp(`awk 'NR==2 {print $6}' $vfile`), [','] => ""))
-   solm_tn = parse(Float64, replace.(readchomp(`awk 'END {print $6}' $vfile`), [','] => ""))
+   solm_t0 = parse(Float64, replace(readchomp(`awk 'NR==2 {print $6}' $vfile`), [','] => ""))
+   solm_tn = parse(Float64, replace(readchomp(`awk 'END {print $6}' $vfile`), [','] => ""))
    # Bed solids masses
-   bsm_t0 = parse(Float64, replace.(readchomp(`awk 'NR==2 {print $7}' $vfile`), [','] => ""))
-   bsm_tn = parse(Float64, replace.(readchomp(`awk 'END {print $7}' $vfile`), [','] => ""))
+   bsm_t0 = parse(Float64, replace(readchomp(`awk 'NR==2 {print $7}' $vfile`), [','] => ""))
+   bsm_tn = parse(Float64, replace(readchomp(`awk 'END {print $7}' $vfile`), [','] => ""))
 
    expected_vol = flux_vol + vol_t0 + b_t0
    final_vol = vol_tn + b_tn

--- a/tests/testlib.jl
+++ b/tests/testlib.jl
@@ -119,17 +119,17 @@ function check_conservativity(dir)
    # ways to do this but they require libraries so less portable.
    #
    # Flow volumes (at start/end of simulation)
-   vol_t0 = parse(Float64, readchomp(`awk 'NR==2 {print $2}' $vfile`)[1:end-1])
-   vol_tn = parse(Float64, readchomp(`awk 'END {print $2}' $vfile`)[1:end-1])
+   vol_t0 = parse(Float64, replace.(readchomp(`awk 'NR==2 {print $2}' $vfile`), [','] => ""))
+   vol_tn = parse(Float64, replace.(readchomp(`awk 'END {print $2}' $vfile`), [','] => ""))
    # Bed volumes
-   b_t0 = parse(Float64, readchomp(`awk 'NR==2 {print $3}' $vfile`)[1:end-1])
-   b_tn = parse(Float64, readchomp(`awk 'END {print $3}' $vfile`)[1:end-1])
+   b_t0 = parse(Float64, replace.(readchomp(`awk 'NR==2 {print $3}' $vfile`), [','] => ""))
+   b_tn = parse(Float64, replace.(readchomp(`awk 'END {print $3}' $vfile`), [','] => ""))
    # Solids masses
-   solm_t0 = parse(Float64, readchomp(`awk 'NR==2 {print $6}' $vfile`)[1:end-1])
-   solm_tn = parse(Float64, readchomp(`awk 'END {print $6}' $vfile`)[1:end-1])
+   solm_t0 = parse(Float64, replace.(readchomp(`awk 'NR==2 {print $6}' $vfile`), [','] => ""))
+   solm_tn = parse(Float64, replace.(readchomp(`awk 'END {print $6}' $vfile`), [','] => ""))
    # Bed solids masses
-   bsm_t0 = parse(Float64, readchomp(`awk 'NR==2 {print $7}' $vfile`)[1:end-1])
-   bsm_tn = parse(Float64, readchomp(`awk 'END {print $7}' $vfile`)[1:end-1])
+   bsm_t0 = parse(Float64, replace.(readchomp(`awk 'NR==2 {print $7}' $vfile`), [','] => ""))
+   bsm_tn = parse(Float64, replace.(readchomp(`awk 'END {print $7}' $vfile`), [','] => ""))
 
    expected_vol = flux_vol + vol_t0 + b_t0
    final_vol = vol_tn + b_tn


### PR DESCRIPTION
Headers columns are underscore separated words.
Columns are comma-separated with no trailing comma
Amended testlib to read columns and remove comma.

Resolves #1 