### PR TITLE
Fix julia test script to run on mac

### DIFF
--- a/tests/testlib.jl
+++ b/tests/testlib.jl
@@ -490,7 +490,7 @@ end
 function links_to_netcdf(prog)
     lib_printer_exec = "ldd" # default library checker
     if Sys.isapple()
-      lib_printer_exec = ["otool", "-L"]
+        lib_printer_exec = ["otool", "-L"]
     end
 
     cmd = `$lib_printer_exec $prog`

--- a/tests/testlib.jl
+++ b/tests/testlib.jl
@@ -490,7 +490,7 @@ end
 function links_to_netcdf(prog)
     lib_printer_exec = "ldd" # default library checker
     if Sys.isapple()
-        lib_printer_exec = "otool -L"
+      lib_printer_exec = ["otool", "-L"]
     end
 
     cmd = `$lib_printer_exec $prog`


### PR DESCRIPTION
Closes #12 

The command line arguments need to be passed as a list of strings (`["otool", "-L"]` rather than "otool -L") to work correctly on mac. Thanks to @fjebaker for the help.

I've done this in this PR and checked it all works on an M2 Macbook air running Ventura.

Part of https://github.com/openjournals/joss-reviews/issues/6079