### PR TITLE
Output as .txt if Format field not recognised

### DIFF
--- a/src/OutputSettings.f90
+++ b/src/OutputSettings.f90
@@ -180,7 +180,10 @@ contains
                   call FatalErrorMessage('NetCDF not active')
 #endif
                 case default
-                  call WarningMessage("In the 'Output' block the value of 'Format' is not recognised.")
+                  call WarningMessage("In the 'Output' block the value of " &
+                                      // "'Format' is not recognised. " &
+                                      // "Using default .txt files")
+                  RunParams%out_txt = .TRUE.
                end select
             end do
 

--- a/src/OutputSettings.f90
+++ b/src/OutputSettings.f90
@@ -164,26 +164,25 @@ contains
             RunParams%kmlHeight = OutputValues(J)%to_real()
 
           case ('format')
-            set_outputFormat=.TRUE.
             call OutputValues(J)%read_list(outputFormat, delimiter=',')
             N_fmts = OutputValues(J)%count_substring(',')+1
             do K=1,N_fmts
                select case (outputFormat(K)%s)
                 case ('txt')
                   RunParams%out_txt = .TRUE.
+                  set_outputFormat=.TRUE.
                 case ('kml')
                   RunParams%out_kml = .TRUE.
+                  set_outputFormat=.TRUE.
                 case ('nc','netcdf')
 #if HAVE_NETCDF4
                   RunParams%out_nc = .TRUE.
+                  set_outputFormat=.TRUE.
 #else
                   call FatalErrorMessage('NetCDF not active')
 #endif
                 case default
-                  call WarningMessage("In the 'Output' block the value of " &
-                                      // "'Format' is not recognised. " &
-                                      // "Using default .txt files")
-                  RunParams%out_txt = .TRUE.
+                  call WarningMessage("In the 'Output' block the setting 'Format = "//outputFormat(K)%s//"' is not recognised.")
                end select
             end do
 
@@ -205,6 +204,7 @@ contains
          end select
       end do
 
+      ! Set defaults for optional settings if not set.
       if (.not.set_basePath) then
          call getcwd(cwd)
          basePath = varString(cwd, trim_str=.TRUE.)
@@ -232,11 +232,11 @@ contains
       end if
 
       if (.not.set_outputFormat) then
+         ! If no recognized output format has been set, default to txt output.
          RunParams%out_txt = .TRUE.
          call WarningMessage("In the 'Output' block in the input file 'Format' is not given.  Using txt output format.")
       end if
 
-      ! Set defaults for optional settings if not set.
       if (.not.set_MaximumsFilename) then
          MaximumsFilename = varString(MaximumsFilename_d)
       end if


### PR DESCRIPTION
This is to address the fact that Kestrel will run simulations with no output if the format field is given by the user but not recognised.
