### PR TITLE
Always store erosion choice in .nc files

### DIFF
--- a/src/Output.f90
+++ b/src/Output.f90
@@ -2068,9 +2068,9 @@ contains
          case ("Manning")
             call put_nc_att(ncid, "Manning coefficient", RunParams%ManningCo)
       end select
+      call put_nc_att(ncid, "erosion choice", RunParams%ErosionChoice%s)
       if (RunParams%MorphodynamicsOn) then
          call put_nc_att(ncid, "morphodynamics time stepping", "on")
-         call put_nc_att(ncid, "erosion choice", RunParams%ErosionChoice%s)
          select case (RunParams%ErosionChoice%s)
             case ('Fluid')
                call put_nc_att(ncid, "fluid erosion rate", RunParams%EroRate)


### PR DESCRIPTION
The QGIS plugin looks for erosion choice and breaks if it can't find this variable. Therefore we should always store it, even if the choice is 'off'.
