### PR TITLE
Bugfix: PROJ segfault on newer GCC versions

### DIFF
--- a/src/TopogSettings.f90
+++ b/src/TopogSettings.f90
@@ -351,7 +351,7 @@ contains
             RunParams%UTM_zone_letter = "N"
          end if
          RunParams%utmEPSG = LatLonToUtmEpsg(RunParams%Lat, RunParams%Lon)
-         RunParams%projTransformer = proj_transformer(RunParams%utmEPSG)
+         call new(RunParams%projTransformer, RunParams%utmEPSG)
          RunParams%centerUTM = RunParams%projTransformer%wgs84_to_utm(RunParams%Lat, RunParams%Lon)
       end if
 

--- a/src/cUTM.cpp
+++ b/src/cUTM.cpp
@@ -64,19 +64,25 @@ proj_transformer::proj_transformer(int utm_code) {
     proj_destroy(P);
     P = norm;
 }
-// C constructor
-PT* proj_transformer__new(int utm_code) {
-    return new proj_transformer(utm_code);
-}
 
 /* Destructor */
 proj_transformer::~proj_transformer() {
     proj_destroy(P);
     proj_context_destroy(C);
 }
+
+extern "C" {
+
+// C constructor
+PT* proj_transformer__new(int utm_code) {
+    return new proj_transformer(utm_code);
+}
+
 // C destructor
 void proj_transformer__delete(PT* self) {
     delete self;
+}
+
 }
 
 /* Method: transform wgs84 latitude--longitude to UTM Easting--Northing*/


### PR DESCRIPTION
This should fix an issue that causes a near-immediate segfault when using georeferencing on kestrel builds compiled with newer versions of GCC (13+).

From what I could tell this was due to the destructor being automatically called after our creator function tried to return it. Presumably due to some scoping issue that I don't currently understand fully. But the fix seems to be to use a subroutine rather than a function so that the object persists.
