### PR TITLE
Fix GDAL linking

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,10 @@ AC_PROG_FC
 AC_FC_LIBRARY_LDFLAGS
 AC_PROG_CXX
 
+# Detect builds on linux
+AC_CANONICAL_HOST
+AM_CONDITIONAL([LINUX], [test x$host_os = xlinux-gnu])
+
 # Check c++17, which we require.
 AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,6 +3,10 @@ AM_FCFLAGS = -g -fcheck=all -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,o
 AM_CXXFLAGS = -g
 else
 AM_FCFLAGS = -O2 -falign-loops=16 -march=native -mtune=native
+if LINUX
+# These optimisation flags are only supported by gcc on linux.
+AM_FCFLAGS += -march=native -mtune=native
+endif
 AM_CXXFLAGS = -O2 -falign-loops=16 
 endif
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,7 +19,7 @@ kestrel_SOURCES = cUTM.cpp RasterData.cpp SetPrecision.f90 \
 
 kestrel_FCFLAGS = -Wall -ffree-line-length-0 -fno-range-check -cpp $(NETCDF4_FFLAGS) $(AM_FCFLAGS) $(DEFS)
 kestrel_CXXFLAGS = -Wall $(GDAL_CFLAGS) $(PROJ_CFLAGS) $(AM_CXXFLAGS)
-kestrel_LDFLAGS = $(NETCDF4_LDFLAGS) $(PROJ_LDFLAGS)
+kestrel_LDFLAGS = $(GDAL_DEP_LDFLAGS) $(GDAL_LDFLAGS) $(NETCDF4_LDFLAGS) $(PROJ_LDFLAGS)
 kestrel_LDADD = $(FCLIBS) $(GDAL_LDFLAGS) $(NETCDF4_FLIBS) $(PROJ_LDFLAGS) $(LIBS)
 
 if WANT_BOOST


### PR DESCRIPTION
These extra linker flags are needed for builds on some systems. The resulting linker line is a little inelegant but that's a small price to pay.

We should check that the build works on all our target platforms before merging.
