### PR TITLE
Edwards 2019 granular friction law

### DIFF
--- a/docs/source/settings_and_parameters/parameters.rst
+++ b/docs/source/settings_and_parameters/parameters.rst
@@ -96,6 +96,58 @@ There are two **required** settings in the *Parameters* block:
 
                 Sets :math:`\beta`, which is required to be strictly positive.
 
+        :code:`edwards2019`
+
+            Sets Edwards et al.'s extension to the Pouliquen law (see e.g. 
+            Edwards, Russell, Johnson, Gray, *J. Fluid Mech.*, **875**, `2019
+            <https://doi.org/10.1017/jfm.2019.517>`_)
+
+                :math:`\mathcal{F} = \mu(Fr, H) g_\perp H`,
+
+            where :math:`g_\perp` is gravitational acceleration resolved
+            perpendicular to the local slope, :math:`Fr = |\mathbf{u}|/\sqrt{g_\perp H}` 
+            is the local Froude number and the friction function is defined as
+
+                :math:`\mu(Fr, H) = \mu_1 + \frac{\mu_2 - \mu_1}{1 + H \beta / (L(Fr + \Gamma))}`,
+
+            when :math:`Fr > \beta_*` and
+
+                :math:`\mu(Fr, H) = \left(\frac{Fr}{\beta_*}\right)^\kappa \left\{\mu_1 + \frac{\mu_2 - \mu_1}{1 + H \beta / (L(\beta_* + \Gamma))} - \mu_{\mathrm{start}(H)}\right\} + \mu_{\mathrm{start}(H)}`
+
+            when :math:`Fr \leq \beta_*`, with :math:`\mu_{\mathrm{start}(H)} =
+            \mu_3 + (\mu_2 - \mu_1) / (1 + H / L)`.
+
+            The following **conditionally optional** settings are used to set
+            the various empirical coefficients in this model:
+
+                :code:`pouliquen min = 0.1`
+
+                Sets :math:`\mu_1`, which is required to be strictly positive.
+            
+                :code:`pouliquen max = 0.4`
+
+                Sets :math:`\mu_2`, which is required to be strictly positive.
+
+                :code:`pouliquen intermediate = 0.2`
+            
+                Sets :math:`\mu_3`, which is required to be strictly positive.
+
+                :code:`pouliquen beta = 0.136`
+
+                Sets :math:`\beta`, which is required to be strictly positive.
+
+                :code:`edwards2019 betastar = 0.136`
+                
+                Sets :math:`\beta_*`, which is required to be strictly positive.
+
+                :code:`edwards2019 kappa = 1.0`
+
+                Sets :math:`\kappa`, which is required to be strictly positive.
+
+                :code:`edwards2019 gamma = 0.0`
+
+                Sets :math:`\Gamma`.
+
         :code:`variable`
 
             Sets the following drag law, which interpolates between the Chézy

--- a/docs/source/settings_and_parameters/parameters.rst
+++ b/docs/source/settings_and_parameters/parameters.rst
@@ -10,8 +10,13 @@ There are two **required** settings in the *Parameters* block:
     :code:`drag = chezy`
 
     This sets the basal drag closure function :math:`\tau_b`, which we assume to
-    be of the form :math:`\tau_b = \frac{\bar{\rho}
-    \bar{\mathbf{u}}}{\mathbf{u}}\mathcal{F}`, where (as detailed in
+    be of the form
+
+    .. math::
+
+        {\tau_b}_{x} = \mathcal{F} \bar{\rho}\bar{u}/|\bar{\mathbf{u}}|, \qquad {\tau_b}_{y} = \mathcal{F} \bar{\rho}\bar{v}/|\bar{\mathbf{u}}|,
+        
+    where (as detailed in
     :ref:`physical_model`) :math:`\mathcal{F}` is a friction function that may
     depend on the local flow variables and any conditionally optional parameters
     relevant to the selected drag law. Options are:
@@ -52,7 +57,7 @@ There are two **required** settings in the *Parameters* block:
 
             Sets the Manning drag law
             
-                :math:`\mathcal{F} = \frac{g_\perp n^2}{H^{1/3}}`,
+                :math:`\mathcal{F} = \dfrac{g_\perp n^2}{H^{1/3}}`,
 
             where :math:`g_\perp` is gravitational acceleration resolved
             perpendicular to the local slope.
@@ -79,7 +84,7 @@ There are two **required** settings in the *Parameters* block:
             sediment diameter, which may be set via the ``solid diameter``
             option.) The friction coefficient is given by
 
-                :math:`\mu(I) = \mu_1 + \frac{\mu_2 - \mu_1}{1 + \beta / I}`
+                :math:`\mu(I) = \mu_1 + \dfrac{\mu_2 - \mu_1}{1 + \beta / I}`
 
             The following **conditionally optional** settings are used to set
             the various empirical coefficients in this model:
@@ -108,11 +113,11 @@ There are two **required** settings in the *Parameters* block:
             perpendicular to the local slope, :math:`Fr = |\mathbf{u}|/\sqrt{g_\perp H}` 
             is the local Froude number and the friction function is defined as
 
-                :math:`\mu(Fr, H) = \mu_1 + \frac{\mu_2 - \mu_1}{1 + H \beta / (L(Fr + \Gamma))}`,
+                :math:`\mu(Fr, H) = \mu_1 + \dfrac{\mu_2 - \mu_1}{1 + H \beta / (L(Fr + \Gamma))}`,
 
             when :math:`Fr > \beta_*` and
 
-                :math:`\mu(Fr, H) = \left(\frac{Fr}{\beta_*}\right)^\kappa \left\{\mu_1 + \frac{\mu_2 - \mu_1}{1 + H \beta / (L(\beta_* + \Gamma))} - \mu_{\mathrm{start}(H)}\right\} + \mu_{\mathrm{start}(H)}`
+                :math:`\mu(Fr, H) = \left(\dfrac{Fr}{\beta_*}\right)^\kappa \left\{\mu_1 + \dfrac{\mu_2 - \mu_1}{1 + H \beta / (L(\beta_* + \Gamma))} - \mu_{\mathrm{start}(H)}\right\} + \mu_{\mathrm{start}(H)}`
 
             when :math:`Fr \leq \beta_*`, with :math:`\mu_{\mathrm{start}(H)} =
             \mu_3 + (\mu_2 - \mu_1) / (1 + H / L)`.
@@ -158,7 +163,7 @@ There are two **required** settings in the *Parameters* block:
 
             where :math:`f` is a switching function, equal to
 
-                :math:`f(\bar{\psi})=\frac{1}{2}[1+\tanh(V_R(\bar{\psi}-\psi^*))]`.
+                :math:`f(\bar{\psi})=\tfrac{1}{2}[1+\tanh(V_R(\bar{\psi}-\psi^*))]`.
 
             Its parameters may be set via the **conditionally optional**
             statements
@@ -200,7 +205,7 @@ There are two **required** settings in the *Parameters* block:
             Erosion occurs when :math:`\theta` exceeds the critical value
             :math:`\theta_c`, determined by the empirical closure
 
-                :math:`\theta_c = \frac{0.3}{1 + 1.2 R} + 0.055[1-\exp(-0.02R)]`,
+                :math:`\theta_c = \dfrac{0.3}{1 + 1.2 R} + 0.055[1-e^{-0.02R}]`,
 
             where :math:`R = d [g (\rho_s/\rho_f - 1) / \nu_w^2]^{1/3}` and
             :math:`\nu_w = 1.2\times 10^{-6}\textrm{m}^2/\textrm{s}` is the
@@ -234,8 +239,8 @@ There are two **required** settings in the *Parameters* block:
             where :math:`\mu(I)` is Pouliquen's friction coefficient (see the
             :code:`drag` discussion above) and 
 
-                :math:`\mu_n = \mu_1 + \frac{\mu_s - \mu_1}{1 +
-                \left(\frac{H}{25d}\right)^2}`
+                :math:`\mu_n = \mu_1 + \dfrac{\mu_s - \mu_1}{1 +
+                \left(H/25d\right)^2}`
 
             with :math:`\mu_s = [\mu_1 + \tan(1^\circ)] / [1 - \mu_1
             \tan(1^\circ)]` (:math:`\mu_1` is set by :code:`pouliquen min`).
@@ -320,7 +325,7 @@ below:
                     using an empirical law based on the solid diameter
                     :math:`d`:
 
-                        :math:`w_s = \frac{\nu_w}{d}\left\{\sqrt{10.36^2 + 1.048R} - 10.36\right\}`,
+                        :math:`w_s = \dfrac{\nu_w}{d}\left\{\sqrt{10.36^2 + 1.048R} - 10.36\right\}`,
 
                     where (as above) :math:`R = d [g (\rho_s/\rho_f - 1) / \nu_w^2]^{1/3}` and
                     :math:`\nu_w = 1.2\times 10^{-6}\textrm{m}^2/\textrm{s}` is the
@@ -342,7 +347,7 @@ below:
                 formulae :math:`a = 2.7 - 0.15 n` and :math:`b = 0.62n - 1.46`
                 where
 
-                    :math:`n = \frac{4.7 + 0.41 (u_p d / \nu_w)^{3/4}}{1 + 0.175
+                    :math:`n = \dfrac{4.7 + 0.41 (u_p d / \nu_w)^{3/4}}{1 + 0.175
                     (u_p d / \nu_w)^{3/4}}`
 
                 (Rowe, P. N, *Chem. Eng. Sci*, **42**, 1987). The constants
@@ -378,9 +383,11 @@ below:
         This has options
 
             * ``off``. Sets :math:`\chi = 1`.
-            * ``rat3``. Sets :math:`\chi = 0` if :math:`H < H_c`,
-              :math:`\chi = 1` if :math:`H > 2 H_c`, :math:`\chi = (\frac{H}{H_c} - 1)^3 [(2 - \frac{H}{H_c})^{3} + (\frac{H}{H_c} - 1)]^{-1}` otherwise.
-            * ``tanh`` (default). Sets :math:`\chi = \frac{1}{2}[1 + \tanh(10
+            * ``rat3``. Sets
+                :math:`\chi = \begin{cases} 0& \text{if $H<H_{c}$,} \\ 
+                1& \text{if $H>2H_{c}$,} \\
+                (\frac{H}{H_c} - 1)^3 [(2 - \frac{H}{H_c})^{3} + (\frac{H}{H_c} - 1)]^{-1}& \text{otherwise.} \end{cases}`
+            * ``tanh`` (default). Sets :math:`\chi = \tfrac{1}{2}[1 + \tanh(10
               \log(H/H_c))]`.
 
     :code:`erosion depth = 1`
@@ -400,7 +407,7 @@ below:
         This has options
 
             * ``off``. Sets :math:`\Theta = 1`.
-            * ``smooth`` (default). Sets :math:`\Theta = \frac{1}{2}[1 +
+            * ``smooth`` (default). Sets :math:`\Theta = \tfrac{1}{2}[1 +
               \tanh(10^5(\Delta b + \Delta b_{\max}))]`.
             * ``step``. Sets :math:`\Theta = 0` if :math:`\Delta b < -\Delta
               b_{\max}`, :math:`\Theta = 1` otherwise.

--- a/src/Closures.f90
+++ b/src/Closures.f90
@@ -54,7 +54,8 @@ module closures_module
    public :: SmoothErosionTransition, StepErosionTransition, NoErosionTransition
 
    public :: DragClosure
-   public :: ChezyDrag, CoulombDrag, VoellmyDrag, PouliquenDrag, ManningDrag, VariableDrag
+   public :: ChezyDrag, CoulombDrag, VoellmyDrag, PouliquenDrag, Edwards2019Drag
+   public :: ManningDrag, VariableDrag
 
    public :: fswitch
    public :: tanhSwitch, rat3Switch, cosSwitch
@@ -461,6 +462,48 @@ contains
          mu = mu1
       end if
    end function PouliquenFrictionCoefficient
+
+   ! Extended 'Pouliquen'-like law featuring velocity-weakening behaviour at 
+   ! low Froude number.
+   ! See Edwards, Russell, Johnson, Gray, J. Fluid Mech. (2019).
+   ! N.B. The Fr = 0 is omitted, since stopped regions require special 
+   ! attention and this is difficult to implement in Kestrel currently.
+   pure function Edwards2019Drag(RunParams, uvect) result(friction)
+      implicit none
+
+      type(RunSet), intent(in) :: RunParams
+      real(kind=wp), dimension(:), intent(in) :: uvect
+      real(kind=wp) :: friction
+
+      real(kind=wp) :: Hn, modu, gam, gperp, mu, Fr
+      real(kind=wp) :: betastar, beta, mu1, mu2, mu3, capgam, L, kappa
+
+      Hn = uvect(RunParams%Vars%Hn)
+      gam = GeometricCorrectionFactor(RunParams, uvect)
+      gperp = RunParams%g / gam
+      modu = sqrt(FlowSquaredSpeedSlopeAligned(RunParams, uvect))
+      Fr = modu / sqrt(gperp * Hn)
+
+      mu1 = RunParams%PouliquenMinSlope
+      mu2 = RunParams%PouliquenMaxSlope
+      mu3 = RunParams%PouliquenIntermediateSlope
+      beta = RunParams%Pouliquenbeta
+      betastar = RunParams%Edwards2019betastar
+      kappa = RunParams%Edwards2019kappa
+      capgam = RunParams%Edwards2019Gamma
+      L = RunParams%SolidDiameter
+
+      if (Fr > betastar) then
+         friction = mu1 + (mu2 - mu1) / (1.0_wp + Hn * beta / (L * (Fr + capgam)))
+      else
+         friction = ((Fr / betastar)**kappa) * &
+             (mu1 + (mu2 - mu1) / (1.0_wp + Hn * beta / (L * (betastar + capgam))) - &
+             mu3 - (mu2 - mu1) / (1.0_wp + Hn / L)) + &
+             mu3 + (mu2 - mu1) / (1.0_wp + Hn / L)
+      end if
+
+      friction = friction * gperp * Hn
+   end function Edwards2019Drag
 
    ! Manning drag has friction function F = g * n^2 / (Hn^{1/3}) where n is the
    ! Manning coefficient.

--- a/src/Parameters.f90
+++ b/src/Parameters.f90
@@ -49,7 +49,11 @@ module parameters_module
    real(kind=wp), parameter :: coulombco_d = 0.1_wp
    real(kind=wp), parameter :: pouliquenMinSlope_d = 0.1_wp
    real(kind=wp), parameter :: pouliquenMaxSlope_d = 0.4_wp
+   real(kind=wp), parameter :: pouliquenIntermediateSlope_d = 0.2_wp
    real(kind=wp), parameter :: pouliquen_beta_d=0.136_wp
+   real(kind=wp), parameter :: edwards2019_betastar_d=0.136_wp
+   real(kind=wp), parameter :: edwards2019_kappa_d=1.0_wp
+   real(kind=wp), parameter :: edwards2019_Gamma_d=0.0_wp
    real(kind=wp), parameter :: EroRate_d = 0.001_wp
    real(kind=wp), parameter :: EroRateGranular_d = 4.0_wp
    real(kind=wp), parameter :: EroDepth_d = 1.0_wp
@@ -102,8 +106,12 @@ contains
       logical :: set_coulombco
       logical :: set_pouliquenMinSlope
       logical :: set_pouliquenMaxSlope
+      logical :: set_pouliquenIntermediateSlope
       logical :: set_pouliquen_beta
       logical :: set_pouliquen_L
+      logical :: set_edwards2019_betastar
+      logical :: set_edwards2019_kappa
+      logical :: set_edwards2019_Gamma
       logical :: set_deposition
       logical :: set_erosion
       logical :: set_EroRate
@@ -135,8 +143,12 @@ contains
       set_coulombco=.FALSE.
       set_pouliquenMinSlope=.FALSE.
       set_pouliquenMaxSlope=.FALSE.
+      set_pouliquenIntermediateSlope=.FALSE.
       set_pouliquen_beta=.FALSE.
       set_pouliquen_L=.FALSE.
+      set_edwards2019_betastar=.FALSE.
+      set_edwards2019_kappa=.FALSE.
+      set_edwards2019_Gamma=.FALSE.
       set_deposition=.FALSE.
       set_erosion=.FALSE.
       set_EroRate=.FALSE.
@@ -269,6 +281,9 @@ contains
                   case ('pouliquen')
                      RunParams%DragChoice = varString('Pouliquen')
                      DragClosure => PouliquenDrag
+                  case ('edwards2019')
+                     RunParams%DragChoice = varString('Edwards2019')
+                     DragClosure => Edwards2019Drag
                   case ('variable')
                      RunParams%DragChoice = varString('Variable')
                      DragClosure => VariableDrag
@@ -306,10 +321,29 @@ contains
                RunParams%PouliquenMaxSlope = ParamValues(J)%to_real()
                if (RunParams%PouliquenMaxSlope<=0) call FatalError_Positive(RunParams%InputFile%s,"Pouliquen Max")
           
+            case ('pouliquen intermediate')
+               set_pouliquenIntermediateSlope=.TRUE.
+               RunParams%PouliquenIntermediateSlope = ParamValues(J)%to_real()
+               if (RunParams%PouliquenIntermediateSlope<=0) call FatalError_Positive(RunParams%InputFile%s,"Pouliquen Intermediate")
+
             case ('pouliquen beta')
                set_pouliquen_beta=.TRUE.
                RunParams%PouliquenBeta = ParamValues(J)%to_real()
                if (RunParams%PouliquenBeta<=0) call FatalError_Positive(RunParams%InputFile%s,"Pouliquen beta")
+
+            case ('edwards2019 betastar')
+               set_edwards2019_betastar=.TRUE.
+               RunParams%Edwards2019betastar = ParamValues(J)%to_real()
+               if (RunParams%Edwards2019betastar<=0) call FatalError_Positive(RunParams%InputFile%s,"Edwards2019 betastar")
+
+            case ('edwards2019 kappa')
+               set_edwards2019_kappa=.TRUE.
+               RunParams%Edwards2019kappa = ParamValues(J)%to_real()
+               if (RunParams%Edwards2019kappa<=0) call FatalError_Positive(RunParams%InputFile%s,"Edwards2019 kappa")
+
+            case ('edwards2019 gamma')
+               set_edwards2019_gamma=.TRUE.
+               RunParams%Edwards2019gamma = ParamValues(J)%to_real()
           
             case ('voellmy switch rate')
                set_VoellmySwitchRate=.TRUE.
@@ -485,7 +519,7 @@ contains
          end if
       end if
 
-      if ((RunParams%DragChoice%s=="Pouliquen").or.(RunParams%DragChoice%s=="Variable")) then
+      if ((RunParams%DragChoice%s=="Pouliquen").or.(RunParams%DragChoice%s=="Variable").or.(RunParams%DragChoice%s=="Edwards2019")) then
          if (.not.set_pouliquenMinSlope) then
             RunParams%PouliquenMinSlope = pouliquenMinSlope_d
             call Warning_DragDefaultValue(RunParams%DragChoice%s,"Pouliquen Min",RunParams%pouliquenMinSlope)
@@ -497,6 +531,24 @@ contains
          if (.not.set_pouliquen_beta) then
             RunParams%PouliquenBeta = pouliquen_beta_d
             call Warning_DragDefaultValue(RunParams%DragChoice%s,"Pouliquen Beta",RunParams%PouliquenBeta)
+         end if
+      end if
+      if (RunParams%DragChoice%s=="Edwards2019") then
+         if (.not.set_pouliquenIntermediateSlope) then
+            RunParams%PouliquenIntermediateSlope = pouliquenIntermediateSlope_d
+            call Warning_DragDefaultValue(RunParams%DragChoice%s,"Pouliquen Intermediate",RunParams%pouliquenIntermediateSlope)
+         end if
+         if (.not.set_edwards2019_betastar) then
+            RunParams%Edwards2019betastar = edwards2019_betastar_d
+            call Warning_DragDefaultValue(RunParams%DragChoice%s,"Edwards2019 betastar",RunParams%Edwards2019betastar)
+         end if
+         if (.not.set_edwards2019_kappa) then
+            RunParams%Edwards2019kappa = edwards2019_kappa_d
+            call Warning_DragDefaultValue(RunParams%DragChoice%s,"Edwards2019 kappa",RunParams%Edwards2019kappa)
+         end if
+         if (.not.set_edwards2019_gamma) then
+            RunParams%Edwards2019gamma = edwards2019_gamma_d
+            call Warning_DragDefaultValue(RunParams%DragChoice%s,"Edwards2019 Gamma",RunParams%Edwards2019Gamma)
          end if
       end if
 

--- a/src/RunSettings.f90
+++ b/src/RunSettings.f90
@@ -223,7 +223,11 @@ module runsettings_module
       real(kind=wp) :: CoulombCo ! Coulomb coefficient
       real(kind=wp) :: PouliquenMinSlope ! Minimum slope angle for steady flow with Pouliquen friction
       real(kind=wp) :: PouliquenMaxSlope ! Maximum slope angle for steady flow with Pouliquen friction
+      real(kind=wp) :: PouliquenIntermediateSlope ! Intermediate slope angle for Pouliquen friction
       real(kind=wp) :: PouliquenBeta ! beta parameter in Pouliquen friction
+      real(kind=wp) :: Edwards2019betastar ! beta* parameter in Edwards' 2019 JFM friction model
+      real(kind=wp) :: Edwards2019kappa ! smoothing power in Edwards' 2019 JFM friction model
+      real(kind=wp) :: Edwards2019Gamma ! Gamma parameter in Edwards' 2019 JFM friction model
       real(kind=wp) :: VoellmySwitchRate ! Steepness of transition in Voellmy drag
       real(kind=wp) :: VoellmySwitchValue ! Centre value of transition in Voellmy drag
       ! Morphodynamic parameters.

--- a/tests/Input_flux_edwards2019.txt
+++ b/tests/Input_flux_edwards2019.txt
@@ -1,0 +1,47 @@
+%%ListType
+
+Domain:
+Lat = 0
+Lon = 0
+nXtiles = 100
+nYtiles = 1
+nXpertile = 100
+nYpertile = 1
+Xtilesize = 100
+Boundary Conditions = halt
+
+Source:
+  sourceX = 0
+  sourceY = 0
+  sourceRadius = 10
+  sourceTime = (0,1000)
+  sourceFlux = (1.,1.)
+  sourceConc = (0.,0.)
+
+Parameters:
+Drag = Edwards2019
+Pouliquen min = 0.11
+Pouliquen max = 0.45
+Pouliquen intermediate = 0.2
+Pouliquen beta = 0.136
+Edwards2019 betastar = 0.136
+Edwards2019 kappa = 1.0
+edwards2019 gamma = 0.0
+Erosion = Off
+Eddy Viscosity = 1e-4
+
+Solver:
+T end = 50
+cfl = 0.5
+max dt = 10
+Tile Buffer = 3
+Height threshold = 1e-6
+
+Output:
+N out = 3
+directory = flux_edwards2019/
+
+Topog:
+Type = Function
+Topog function = xSlope
+Topog params = (0.2)

--- a/tests/Input_flux_edwards2019_2d.txt
+++ b/tests/Input_flux_edwards2019_2d.txt
@@ -1,0 +1,41 @@
+%%ListType
+
+Domain:
+Lat = 0
+Lon = 0
+nXtiles = 40
+nYtiles = 40
+nXpertile = 50
+nYpertile = 50
+Xtilesize = 50
+Boundary Conditions = halt
+
+Source:
+  sourceX = 0
+  sourceY = 0
+  sourceRadius = 10
+  sourceTime = (0,1.)
+  sourceFlux = (10.,10.)
+  sourceConc = (0.,0.)
+
+Parameters:
+Drag = Edwards2019
+Erosion = Off
+
+Solver:
+T end = 10.0
+cfl = 0.25
+max dt = 10
+Tile Buffer = 3
+Height threshold = 1e-6
+Restart = off
+
+Output:
+N out = 2
+directory = flux_edwards2019_2d/
+
+Topog:
+Type = Function
+Topog function = xSlope
+Topog params = (-0.1)
+

--- a/tests/runall.jl
+++ b/tests/runall.jl
@@ -7,6 +7,7 @@ tests_1d = [
    ("cap_conc", 1)
    ("cap_morpho", 1)
    ("flux_hydro", 1)
+   ("flux_edwards2019", 1)
    ("flux_morpho", 1)
 ]
 
@@ -16,6 +17,7 @@ tests_2d = [
    ("cap_conc_2d", 2)
    ("cap_morpho_2d", 2)
    ("flux_hydro_2d", 2)
+   ("flux_edwards2019_2d", 2)
    ("flux_morpho_2d", 2)
    ("flux_single_pt", 2)
 ]


### PR DESCRIPTION
Implementation of the friction law in the Edwards et al 2019 JFM article doi:10.1017/jfm.2019.517.

This would be nice to merge in and convenient for me in particular. Only real issue is that there are many such friction laws and all subtly different. But I have updated the documentation to give the exact formula.

Also, the code needed to handle static deposits is tricky to do cleanly in Kestrel... but I don't see harm in having this as an option for now, even without that.
