### PR TITLE
Version tags

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,45 @@
+name: Build and test
+
+# Trigger the workflow on push or pull request events
+on:
+  push:
+    branches:
+      - main
+      - testing
+  pull_request:
+    branches:
+      - main
+      - testing
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgdal-dev libproj22 libproj-dev netcdf-bin libnetcdff-dev
+
+      - name: Build configure script
+        run: autoreconf -fi
+
+      - name: Run configure script
+        run: ./configure
+
+      - name: Build kestrel
+        run: make
+
+      - name: Run tests
+        run: make check
+
+      - name: Save logs
+        if: ${{ always() }} # run regardless of whether build/test succeeded
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs
+          path: tests/*.log
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ started
 ## Testing ##
 
 The full test suite for Kestrel makes use of the Julia language. If you have
-this installed, it may be run by changing to the ./tests directory and issuing
-the command
+this installed, it may be run via `make check`, or by  changing to the ./tests
+directory and issuing the command
 
 > `julia runall.jl`
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,6 @@
-AC_INIT([Kestrel], [1.0], [Mark.Woodhouse@bristol.ac.uk, J.Langham@bristol.ac.uk])
+AC_INIT([Kestrel], 
+        [m4_esyscmd_s([git describe --tags])], 
+        [Mark.Woodhouse@bristol.ac.uk, J.Langham@bristol.ac.uk])
 AC_CONFIG_SRCDIR([src/TimeStepper.f90])
 AC_CONFIG_MACRO_DIRS([m4])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])

--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,10 @@ AC_PROG_FC
 AC_FC_LIBRARY_LDFLAGS
 AC_PROG_CXX
 
+# Detect builds on linux
+AC_CANONICAL_HOST
+AM_CONDITIONAL([LINUX], [test x$host_os = xlinux-gnu])
+
 # Check c++17, which we require.
 AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
 

--- a/docs/source/settings_and_parameters/solver.rst
+++ b/docs/source/settings_and_parameters/solver.rst
@@ -66,6 +66,62 @@ The **optional** settings of the solver block are:
                 .. note::
                         As the governing equations are hyperbolic, solutions can exhibit discontinuities.  Therefore, :code:`None` is **not** recommended.
 
+    :code:`desingularization = L1`
+
+        A desingularization formula is used to compute the reciprocal of a value while avoiding blow-up when dividing by a small number.
+
+        These functions compute :math:`1/x` and use a threshold value, :math:`\epsilon`.
+        The functions return a value :math:`1/x` for :math:`x>\epsilon`, but a thresholded value for :math:`x < \epsilon`.
+        The value of :math:`\epsilon` is specified using :code:`height threshold` when computing :math:`1/H`.
+
+        Commonly used desingularization formulae have the form
+
+            .. math::
+                \frac{1}{x} = \frac{\alpha x}{\left|\left|x^{2},\max\left(x^{2},\epsilon^{2}\right)\right|\right|_{p}}
+        
+        with :math:`||\cdot,\cdot||_{p}` representing the p-norm, and :math:`\alpha = ||1,1||_{p}`.
+
+        For example, `Chertock et al (2015) <https://doi.org/10.1002/fld.4023>`_ uses the L1-norm, 
+        `Kurganov & Petrova (2007) <http://dx.doi.org/10.4310/CMS.2007.v5.n1.a6>`_ uses the L2-norm,
+        and this could reasonably be continued, and culminate in the infinity-norm (so that :math:`1/x = x/\epsilon^2` for :math:`x<\epsilon`).
+        The naming of the desingularization formulae below is based on this, with the exception of desingularization formula of `Bollermann et al (2013) <https://doi.org/10.1007/s10915-012-9677-5>`_ who use a step-function
+        with :math:`1/x = 0` for :math:`x<\epsilon` -- we call this Desingularize_step.
+
+        Options are:
+
+            :code:`L1` or :code:`Chertock`
+
+                The desingularization formula of `Chertock et al (2015) <https://doi.org/10.1002/fld.4023>`_, 
+                using the L1-norm, given by
+
+                .. math::
+                    \frac{1}{x} = \frac{2x}{x^{2}+\max\left(x^{2},\epsilon^{2}\right)}
+
+            :code:`L2` or :code:`Kurganov`
+
+                The desingularization formula of `Kurganov & Petrova (2007) <http://dx.doi.org/10.4310/CMS.2007.v5.n1.a6>`_,
+                using the L2-norm, given by
+
+                .. math::
+                    \frac{1}{x} = \frac{\sqrt{2}x}{\sqrt{x^{4}+\max\left(x^{4},\epsilon^{4}\right)}}
+
+            :code:`Linf` or :code:`Linfty` or :code:`Linfinity`
+
+                The desingularization using the L\ :math:`\infty`-norm, given by
+
+                .. math::
+                    \frac{1}{x} = \frac{x}{\max\left(x^{2},\epsilon^{2}\right)}
+            
+            :code:`step` or :code:`Bollermann`
+
+                The desingularization formula of `Bollermann et al (2013) <https://doi.org/10.1007/s10915-012-9677-5>`_,
+                given by
+
+                .. math::
+                    \frac{1}{x} = \left\{\begin{array}{lr} 1/x, &\text{for } x\ge\epsilon\\
+                                                             0, &\text{for } x<\epsilon
+                                        \end{array}\right.
+
     :code:`height threshold = 1e-6`
 
         A threshold on flow depths.  Flow depths below :code:`height threshold` are neglected.

--- a/docs/source/settings_and_parameters/topog.rst
+++ b/docs/source/settings_and_parameters/topog.rst
@@ -139,6 +139,24 @@ functions:
             - :code:`phi2` -- the slope angle for :math:`x\to +\infty`, in degrees.  A positive value corresponds to an elevation decreasing from left to right.
             - :code:`lambda` -- the characteristic length scale of the smooth transition region.
 
+    :code:`Topog function = xTrislope`
+
+        A surface with three constant slopes connected piecewise continuously 
+        by trigonometric functions over a characteristic length scale
+        :math:`\lambda`.
+
+        :code:`Topog params = (phi1, phi2, phi3, lambda, x1, x2)`
+
+            - :code:`phi1` -- the slope angle :math:`\phi_1` for :math:`x<(x_1-\lambda/2)`, in degrees.  A positive value corresponds to an elevation decreasing from left to right.
+            - :code:`phi2` -- the slope angle :math:`\phi_2` for :math:`(x_1-\lambda/2)<x<(x_2-\lambda/2)`, in degrees.  A positive value corresponds to an elevation decreasing from left to right.
+            - :code:`phi3` -- the slope angle :math:`\phi_3` for :math:`(x_2-\lambda/2)<x`, in degrees.  A positive value corresponds to an elevation decreasing from left to right.
+            - :code:`lambda` -- the length scale :math:`\lambda` over which transitions between
+              constant slope values occur.
+            - :code:`x1` -- the point :math:`x_1` where the transition between
+              :math:`\phi_1` and :math:`\phi_2` is centred.
+            - :code:`x2` -- the point :math:`x_2` where the transition between
+              :math:`\phi_2` and :math:`\phi_3` is centred.
+
     :code:`Topog function = USGS`
 
         Parametrisation of the USGS flume.  This has slope of 31° for
@@ -152,7 +170,67 @@ functions:
         :code:`Topog params = (wallH, sigma)`
 
             - :code:`wallH` -- the height of the sidewalls of the flume.
-            - :code:`sigma` -- the width of the sidewalls of the flume.
+            - :code:`sigma` -- the characteristic lateral slope of the channel
+              banks, which are centred at :math:`y=\pm 3/2`. 
+              Note that sufficiently low :code:`sigma` values also
+              control the effective width of the channel.
+
+    :code:`Topog function = flume`
+
+        Generalised USGS flume geometry that requires six parameters to specify
+        its features. It defines a channel at slope angle :math:`\theta_0` for
+        :math:`x<0`, confined by walls for :math:`x<x_{\mathrm{wall}}` that
+        smoothly connects to an unconfined runout plane of slope angle
+        :math:`\theta_1` for :math:`x>x_1>0` (note that :math:`x_1` is
+        determined to ensure the smooth connection).
+        The confining walls are constructed by :math:`\tanh` bumps, centred at
+        :math:`y=\pm W` with characteristic width :math:`W`.
+
+        :code:`Topog params = (theta0, theta1, xwall, wallW, wallH, sigma)`
+
+            - :code:`theta0` -- the slope (in degrees) for :math:`x < 0`.
+            - :code:`theta1` -- the slope (in degrees) for :math:`x > x_1`.
+            - :code:`xwall` -- :math:`x_{\mathrm{wall}}` coordinate defining the
+              transition between confined and unconfined parts of the topography.
+            - :code:`wallW` -- the characteristic width :math:`W` of the channel.
+            - :code:`wallH` -- the height of the sidewalls of the flume.
+            - :code:`sigma` -- the characteristic lateral slope of the channel
+              banks, which are centred at :math:`y=\pm W`.
+              Note that sufficiently low :code:`sigma` values also
+              control the effective width of the channel.
+
+    :code:`Topog function = channel power law`
+    
+        Channel with constant slope in :math:`x` and banks defined by a power law as so
+
+        :math:`b(x, y) = Sx + \cos(\theta)|y/W|^\alpha`,
+
+        where :math:`S = \tan(\theta)` is the slope in :math:`x` and :math:`W`, 
+        :math:`\alpha` are parameters defining a power law cross-section.
+
+        :code:`Topog params = (slope, W, alpha)`
+
+            - :code:`slope` -- the slope :math:`S` in :math:`x`.
+            - :code:`W` -- the characteristic width :math:`W` of the power law
+              cross-section.
+            - :code:`alpha` -- index :math:`\alpha` of the power law.
+
+    :code:`Topog function = channel trapezium`
+
+        Channel with constant slope in :math:`x` and banks defined by a trapezium as so
+
+        :math:`b(x, y) = Sx + \cos(\theta)\max\{0, S_b (|y| - W/2)\}`,
+
+        where :math:`S = \tan(\theta)` is the slope in :math:`x`, :math:`W` is
+        the width of the trapezoid cross-section and :math:`S_b` is the slope of
+        the banks in a frame oriented along the channel.
+
+        :code:`Topog params = (slope, W, Sb)`
+
+            - :code:`slope` -- the slope :math:`S` in :math:`x`.
+            - :code:`W` -- the width of the channel base.
+            - :code:`Sb` -- the gradient of the banks in slope-aligned
+              coordinates.
 
     :code:`Topog function = xsinslope`
 

--- a/src/Closures.f90
+++ b/src/Closures.f90
@@ -430,11 +430,7 @@ contains
 
       mu = PouliquenFrictionCoefficient(RunParams, g, Hn, sqrt(modu2))
 
-      if (modu2 > 0) then
-         friction = mu * g * Hn
-      else
-         friction = 0.0_wp
-      end if
+      friction = mu * g * Hn
    end function PouliquenDrag
 
    ! Pouliquen's intertial number dependent friction coefficient.
@@ -524,11 +520,8 @@ contains
       g = RunParams%g / gam
 
       ManningCo = RunParams%ManningCo
-      if (Hn > RunParams%heightThreshold) then
-         friction = g * ManningCo*ManningCo / (Hn**(1.0_wp/3.0_wp))
-      else
-         friction = 0.0_wp
-      end if
+
+      friction = g * ManningCo*ManningCo / (Hn**(1.0_wp/3.0_wp))
    end function ManningDrag
 
    ! Variable drag parameterization. This is a concentration-dependent

--- a/src/Closures.f90
+++ b/src/Closures.f90
@@ -484,14 +484,13 @@ contains
       real(kind=wp), dimension(:), intent(in) :: uvect
       real(kind=wp) :: friction
 
-      real(kind=wp) :: Hn, modu, gam, gperp, mu, Fr
+      real(kind=wp) :: Hn, modu, gam, gperp, gperp_Hn_recip, mu, Fr
       real(kind=wp) :: betastar, beta, mu1, mu2, mu3, capgam, L, kappa
 
       Hn = uvect(RunParams%Vars%Hn)
       gam = GeometricCorrectionFactor(RunParams, uvect)
       gperp = RunParams%g / gam
       modu = sqrt(FlowSquaredSpeedSlopeAligned(RunParams, uvect))
-      Fr = modu / sqrt(gperp * Hn)
 
       mu1 = RunParams%PouliquenMinSlope
       mu2 = RunParams%PouliquenMaxSlope
@@ -501,6 +500,9 @@ contains
       kappa = RunParams%Edwards2019kappa
       capgam = RunParams%Edwards2019Gamma
       L = RunParams%SolidDiameter
+
+      gperp_Hn_recip = gperp * DesingularizeFunc(Hn, RunParams%heightThreshold * gam)
+      Fr = modu * sqrt(gperp_Hn_recip)
 
       if (Fr > betastar) then
          friction = mu1 + (mu2 - mu1) / (1.0_wp + Hn * beta / (L * (Fr + capgam)))

--- a/src/Input.f90
+++ b/src/Input.f90
@@ -55,7 +55,7 @@ contains
 
       implicit none
 
-      type(RunSet), intent(out) :: RunParams
+      type(RunSet), intent(inout) :: RunParams
       logical :: FileExists
       integer :: stat ! Status of input/output
       type(varString) :: line

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,6 +3,10 @@ AM_FCFLAGS = -g -fcheck=all -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,o
 AM_CXXFLAGS = -g
 else
 AM_FCFLAGS = -O2 -falign-loops=16 -march=native -mtune=native
+if LINUX
+# These optimisation flags are only supported by gcc on linux.
+AM_FCFLAGS += -march=native -mtune=native
+endif
 AM_CXXFLAGS = -O2 -falign-loops=16 
 endif
 
@@ -19,7 +23,7 @@ kestrel_SOURCES = cUTM.cpp RasterData.cpp SetPrecision.f90 \
 
 kestrel_FCFLAGS = -Wall -ffree-line-length-0 -fno-range-check -cpp $(NETCDF4_FFLAGS) $(AM_FCFLAGS) $(DEFS)
 kestrel_CXXFLAGS = -Wall $(GDAL_CFLAGS) $(PROJ_CFLAGS) $(AM_CXXFLAGS)
-kestrel_LDFLAGS = $(NETCDF4_LDFLAGS) $(PROJ_LDFLAGS)
+kestrel_LDFLAGS = $(GDAL_DEP_LDFLAGS) $(GDAL_LDFLAGS) $(NETCDF4_LDFLAGS) $(PROJ_LDFLAGS)
 kestrel_LDADD = $(FCLIBS) $(GDAL_LDFLAGS) $(NETCDF4_FLIBS) $(PROJ_LDFLAGS) $(LIBS)
 
 if WANT_BOOST

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,8 +34,11 @@ kestrel_LDADD += -lstdc++fs
 endif
 
 if HAVE_JULIA
-all-local:
-	ln -sf $(JULIA) ../tests/julia
+check:
+	cd ../tests && $(JULIA) runall.jl
+else
+check:
+	echo "Error: Working Julia executable is required to run test suite" && exit 1
 endif
 
 mostlyclean-local:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,7 +19,7 @@ kestrel_SOURCES = cUTM.cpp RasterData.cpp SetPrecision.f90 \
 	SolverSettings.f90 OutputSettings.f90 TopogSettings.f90 Input.f90 Grid.f90 \
     Equations.f90 HydraulicRHS.f90 MorphodynamicRHS.f90 Redistribute.f90 \
     dem.f90 UpdateTiles.f90 SetSources.f90 NetCDFUtils.f90 \
-    Output.f90 Restart.f90 TimeStepper.f90 main.f90
+    Output.f90 Restart.f90 TimeStepper.f90 cversion.cpp version.f90 main.f90
 
 kestrel_FCFLAGS = -Wall -ffree-line-length-0 -fno-range-check -cpp $(NETCDF4_FFLAGS) $(AM_FCFLAGS) $(DEFS)
 kestrel_CXXFLAGS = -Wall $(GDAL_CFLAGS) $(PROJ_CFLAGS) $(AM_CXXFLAGS)

--- a/src/NetCDFUtils.f90
+++ b/src/NetCDFUtils.f90
@@ -87,7 +87,8 @@ module netcdf_utils_module
 
    interface get_nc_att
       module procedure :: get_nc_att_int, get_nc_att_real, &
-         get_nc_att_int_vec, get_nc_att_real_vec
+         get_nc_att_int_vec, get_nc_att_real_vec, &
+         get_nc_att_str
    end interface
 
 contains
@@ -887,6 +888,27 @@ contains
       val = real(nc_val, kind=wp)
       return
    end subroutine get_nc_att_real_vec
+
+   subroutine get_nc_att_str(ncid, att_name, val)
+    integer, intent(in) :: ncid
+    character(len=*), intent(in) :: att_name
+    character(len=:), allocatable, intent(out) :: val
+
+    integer :: nc_status
+    integer :: length
+
+    nc_status = nf90_inquire_attribute(ncid, NF90_GLOBAL, att_name, len=length)
+    if (nc_status /= NF90_NOERR) then
+        val = "Unknown"
+        return
+    end if
+
+    allocate(character(len=length) :: val)
+
+    nc_status = nf90_get_att(ncid, NF90_GLOBAL, att_name, val)
+    if (nc_status /= NF90_NOERR) call handle_err(nc_status, ' nf90_get_att '//att_name)
+    return
+ end subroutine get_nc_att_str
 
    subroutine handle_err(status, extra)
       integer, intent(in) :: status

--- a/src/Output.f90
+++ b/src/Output.f90
@@ -254,7 +254,8 @@ contains
 
       write (101, fmt="(a12,a4,a1,a2,a1,a2,a1,a4)") "# Run start = ", RunParams%RunDate%s(1:4), "-", RunParams%RunDate%s(5:6), &
          "-", RunParams%RunDate%s(7:8), " ", RunParams%RunTime%s(1:4)
-      write (101, fmt="(a18,a)") "# Input file name = ", RunParams%InputFile%s
+      write (101, fmt="(a20,a)") "# Kestrel version = ", RunParams%version%s
+      write (101, fmt="(a20,a)") "# Input file name = ", RunParams%InputFile%s
       write (101, *)
 
       write (101, fmt="(a)") "Domain:"
@@ -1033,7 +1034,8 @@ contains
       call put_nc_att(ncid, 'title', 'Kestrel: '//trim(filename))
       call put_nc_att(ncid, 'institution', 'University of Bristol')
       call put_nc_att(ncid, 'source', 'Kestrel')
-
+      call put_nc_att(ncid, 'version', RunParams%version%s)
+      
       call put_nc_att(ncid, 'Conventions', 'CF-1.11-draft')
       call put_nc_att(ncid, '_FillValue', -9999.9_wp)
 
@@ -1442,6 +1444,7 @@ contains
       call put_nc_att(ncid, 'title', 'Kestrel: Maximums')
       call put_nc_att(ncid, 'institution', 'University of Bristol')
       call put_nc_att(ncid, 'source', 'Kestrel')
+      call put_nc_att(ncid, 'version', RunParams%version%s)
 
       call put_nc_att(ncid, 'Conventions', 'CF-1.11-draft')
       call put_nc_att(ncid, '_FillValue', -9999.9_wp)

--- a/src/Output.f90
+++ b/src/Output.f90
@@ -418,6 +418,7 @@ contains
 
       write (101, fmt="(a)") "Solver:"
       write (101, fmt="(a,a)") "limiter = ", RunParams%limiter%s
+      write (101, fmt="(a,a)") "desingularization = ", RunParams%desingularization%s
       write (101, fmt="(a,G0)") "height threshold = ", RunParams%heightThreshold
       write (101, fmt="(a,i0)") "Tile buffer = ", RunParams%TileBuffer
       write (101, fmt="(a,G0)") "CFL = ", RunParams%cfl
@@ -2014,6 +2015,7 @@ contains
       call put_nc_att(ncid, "centre_latitude", RunParams%Lat)
       call put_nc_att(ncid, "centre_longitude", RunParams%Lon)
       call put_nc_att(ncid, "limiter", RunParams%limiter)
+      call put_nc_att(ncid, "desingularization", RunParams%desingularization)
       call put_nc_att(ncid, "heightThreshold", RunParams%heightThreshold)
       if (RunParams%SpongeLayer) then
          call put_nc_att(ncid, "SpongeLayer", 'On')

--- a/src/RunSettings.f90
+++ b/src/RunSettings.f90
@@ -159,6 +159,8 @@ module runsettings_module
    ! the simulation. It is subdivided into sections which each have their own
    ! module for initialisation in the files *Settings.f90 and Parameters.f90. 
    type RunSet
+   ! -- Version --
+      type(varString) :: version
 
    ! -- Domain settings. --
 

--- a/src/RunSettings.f90
+++ b/src/RunSettings.f90
@@ -267,6 +267,7 @@ module runsettings_module
       ! Small height below which desingularisation for derived variables (e.g.
       ! u & v) is applied in the numerical scheme. Also used elsewhere when we
       ! occasionally need to define cutoffs based on flow depth.
+      type(varString) :: desingularization
       real(kind=wp) :: heightThreshold
       ! Sets a buffer around flowing area where tiles are activated.
       integer :: TileBuffer

--- a/src/TopogFuncs.f90
+++ b/src/TopogFuncs.f90
@@ -37,7 +37,11 @@
 ! Currently implemented formulae are:
 !   x2slopes - Two slopes connected by a circular arc
 !   usgs - Parameterization of the USGS flume
+!   flume - General flume based on the USGS flume
+!   channel_powerlaw - Slope along x, power law cross section in y
+!   channel_trapezium - Slope along x, trapezium cross section in y
 !   xbislope - Two slopes with smooth transition
+!   xtrislope - Three slopes with piecewise continuous transition
 !   flat - Flat topography
 !   xslope - Uniform slope along x
 !   yslope - Uniform slope along y
@@ -59,7 +63,11 @@ module topog_funcs_module
    public :: TopogFunc ! Generic template for topography formulae
    public :: x2slopes ! Two slopes connected by a circular arc
    public :: usgs ! Parameterization of the USGS flume
+   public :: flume ! General flume based on the USGS flume
+   public :: channel_powerlaw ! Slope along x, power law cross section in y
+   public :: channel_trapezium ! Slope along x, trapezium cross section in y
    public :: xbislope ! Two slopes with smooth transition
+   public :: xtrislope ! Three slopes with piecewise continuous transition
    public :: flat ! Flat topography
    public :: xslope ! Uniform slope along x
    public :: yslope ! Uniform slope along y
@@ -174,6 +182,131 @@ contains
       return
    end subroutine usgs
 
+   ! Parameterization of the general flume
+   ! This has slope theta0 for x<0, and slope theta1 for x>x1>0
+   ! that are connected by a smooth cosh curve section.
+   ! Note x1 is determined to ensure smooth connection.
+   ! The channel is confined by walls for x<xwall, that are represented as tanh profile humps
+   !  parameters required:
+   !  theta0 -- slope (in degrees) for x<0; passed in RunParams%TopogFuncParams(1)
+   !  theta1 -- slope (in degrees) for x>x1; passed in RunParams%TopogFuncParams(2)
+   !  xwall -- x coordinate for end of wall; passed in RunParams%TopogFuncParams(3)
+   !  wallW -- width of confining walls; passed in RunParams%TopogFuncParams(4)
+   !  wallH -- height of confining walls; passed in RunParams%TopogFuncParams(5)
+   !  sigma -- 'width' of tanh walls; passed in RunParams%TopogFuncParams(6)
+   pure subroutine flume(RunParams, x, y, b0)
+      type(RunSet), intent(in) :: RunParams
+      real(kind=wp), dimension(:), intent(in) :: x
+      real(kind=wp), dimension(:), intent(in) :: y
+      real(kind=wp), dimension(:,:), intent(out) :: b0(size(x),size(y))
+
+      real(kind=wp) :: theta0, theta1, xwall, wallW, wallH, sigma
+      real(kind=wp) :: alpha, xc0, zc0, x1
+      integer :: ii, jj
+
+      ! Get parameters
+      theta0 = RunParams%TopogFuncParams(1)
+      theta1 = RunParams%TopogFuncParams(2)
+      xwall = RunParams%TopogFuncParams(3)
+      wallW = RunParams%TopogFuncParams(4)
+      wallH = RunParams%TopogFuncParams(5)
+      sigma = RunParams%TopogFuncParams(6)
+   
+      ! Set parameters
+      alpha = 8.5_wp/(asinh(-tan(4.0_wp*pi/180_wp))-asinh(-tan(theta0*pi/180_wp)))
+      xc0 = - alpha*asinh(-tan(theta0*pi/180.0_wp))
+      zc0 = -alpha*cosh((-xc0)/alpha)
+      x1 = xc0 + alpha*asinh(-tan(theta1*pi/180.0_wp))
+      
+      ! Build topography along x
+      do ii=1,size(x)
+         if (x(ii)<0.0_wp) then
+            b0(ii,:) = -tan(theta0*pi/180.0_wp)*x(ii)
+         elseif (x(ii)>x1) then
+            b0(ii,:) = zc0 + alpha*cosh((x1-xc0)/alpha) - tan(theta1*pi/180.0_wp)*(x(ii)-x1)
+         else
+            b0(ii,:) = zc0 + alpha*cosh((x(ii)-xc0)/alpha)
+         end if
+      end do
+
+      ! Add confining walls
+      do ii=1,size(x)
+         if (x(ii)<xwall) then
+            do jj=1,size(y)
+               b0(ii,jj) = b0(ii,jj) + 0.5_wp*wallH*(tanh(sigma*(y(jj)-0.5_wp*wallW)) &
+                  - tanh(sigma*(y(jj)-1.5_wp*wallW)) + tanh(sigma*(y(jj)+1.5_wp*wallW)) - tanh(sigma*(y(jj)+0.5_wp*wallW)))
+            end do
+         end if
+      end do
+      return
+   end subroutine flume
+
+   ! Channel with constant slope in x and banks defined by a power law as so
+   !
+   ! b(x, y) = x * slope + cos(theta) * (|y| / W)^alpha
+   !
+   ! where theta is the slope angle and accounts for the rotation of the banks
+   ! to the Earth-centred system.
+   ! Note that 2*W sets the approximate width of the channel.
+   !  parameters required:
+   !  slope  -- slope in x.
+   !  W      -- characteristic width of power law channel cross section.
+   !  alpha  -- index of the power law.
+   pure subroutine channel_powerlaw(RunParams, x, y, b0)
+      type(RunSet), intent(in) :: RunParams
+      real(kind=wp), dimension(:), intent(in) :: x
+      real(kind=wp), dimension(:), intent(in) :: y
+      real(kind=wp), dimension(:,:), intent(out) :: b0(size(x),size(y))
+
+      integer :: ii, jj
+      real(kind=wp) :: slope, W, alpha, costheta
+
+      slope = RunParams%TopogFuncParams(1)
+      W = RunParams%TopogFuncParams(2)
+      alpha = RunParams%TopogFuncParams(3)
+
+      costheta = cos(atan(slope))
+   
+      do ii = 1, size(x)
+         do jj = 1, size(y)
+            b0(ii, jj) = slope * x(ii) + costheta * (abs(y(jj)) / W)**alpha
+         end do
+      end do
+      
+   end subroutine channel_powerlaw
+
+   ! Channel with constant slope in x and banks defined by a trapezium as so
+   !
+   ! b(x, y) = x * slope + cos(theta) * max{0, Sb (|y| - W/2)}
+   !
+   ! where theta is the slope angle and accounts for the rotation of the banks
+   ! to the Earth-centred system.
+   !  parameters required:
+   !  slope  -- slope in x.
+   !  W      -- width of trapezium base.
+   !  Sb     -- gradient of the banks in slope-aligned coordinates.
+   pure subroutine channel_trapezium(RunParams, x, y, b0)
+      type(RunSet), intent(in) :: RunParams
+      real(kind=wp), dimension(:), intent(in) :: x
+      real(kind=wp), dimension(:), intent(in) :: y
+      real(kind=wp), dimension(:,:), intent(out) :: b0(size(x),size(y))
+
+      integer :: ii, jj
+      real(kind=wp) :: slope, W, Sb, costheta
+
+      slope = RunParams%TopogFuncParams(1)
+      W = RunParams%TopogFuncParams(2)
+      Sb = RunParams%TopogFuncParams(3)
+
+      costheta = cos(atan(slope))
+
+      do ii = 1, size(x)
+         do jj = 1, size(y)
+            b0(ii, jj) = slope * x(ii) + costheta * max(0.0_wp, Sb * (abs(y(jj)) - 0.5_wp * W))
+         end do
+      end do
+   end subroutine channel_trapezium
+
    ! Two slopes with smooth transition
    ! Three parameters required:
    !  phi1 -- angle of slope in degrees on left-hand-side; passed in RunParams%TopogFuncParams(1)
@@ -202,6 +335,57 @@ contains
       end do
    return
    end subroutine xbislope
+
+   ! Three constant slopes in x connected via piecewise continuous transitions 
+   ! via cosine functions at at x = x1, x2 with slopes s1, s2, s3.
+   ! Six parameters required:
+   !  phi1, phi2, phi3 -- angle of slopes 1,2,3 in degrees
+   !  lam -- length scale of connecting sine curves
+   !  x1, x2 -- locations of the two transition points x = x1 (connecting 
+   !            slopes 1 & 2), x2 (connecting slopes 2 & 3)
+   pure subroutine xtrislope(RunParams, x, y, b0)
+      type(RunSet), intent(in) :: RunParams
+      real(kind=wp), dimension(:), intent(in) :: x
+      real(kind=wp), dimension(:), intent(in) :: y
+      real(kind=wp), dimension(:,:), intent(out) :: b0(size(x),size(y))
+
+      real(kind=wp) :: phi1, phi2, phi3, lam, s1, s2, s3, x1, x2
+      real(kind=wp) :: c2, c3, c4, c5, A
+      integer :: ii
+
+      phi1 = RunParams%TopogFuncParams(1) * pi / 180.0_wp
+      phi2 = RunParams%TopogFuncParams(2) * pi / 180.0_wp
+      phi3 = RunParams%TopogFuncParams(3) * pi / 180.0_wp
+      lam = RunParams%TopogFuncParams(4)
+      x1 = RunParams%TopogFuncParams(5)
+      x2 = RunParams%TopogFuncParams(6)
+      s1 = tan(phi1)
+      s2 = tan(phi2)
+      s3 = tan(phi3)
+
+      c2 = (x1 - 0.5_wp * lam) * 0.5_wp * (s1 - s2)
+      c3 = (x1 + 0.5_wp * lam) * 0.5_wp * (s1 - s2) + c2
+      c4 = (x2 - 0.5_wp * lam) * 0.5_wp * (s2 - s3) + c3
+      c5 = (x2 + 0.5_wp * lam) * 0.5_wp * (s2 - s3) + c4
+
+      ! Build topography
+      do ii = 1, size(x)
+         if (x(ii) < x1 - 0.5_wp * lam) then
+            b0(ii,:) = s1 * x(ii)
+         elseif (x(ii) < x1 + 0.5_wp * lam) then
+            A = 0.5_wp * (s2 - s1) * lam / pi
+            b0(ii,:) = A * sin((x(ii) - x1) * pi / lam - 0.5_wp * pi) + 0.5_wp * (s1 + s2) * x(ii) + c2
+         elseif (x(ii) < x2 - 0.5_wp * lam) then
+            b0(ii,:) = s2 * x(ii) + c3
+         elseif (x(ii) < x2 + 0.5_wp * lam) then
+            A = 0.5_wp * (s3 - s2) * lam / pi
+            b0(ii,:) = A * sin((x(ii) - x2) * pi / lam - 0.5_wp * pi) + 0.5_wp * (s2 + s3) * x(ii) + c4
+         else
+            b0(ii,:) = s3 * x(ii) + c5
+         endif
+      end do
+
+   end subroutine xtrislope
 
    ! Flat topography
    pure subroutine flat(RunParams, x, y, b0)

--- a/src/TopogSettings.f90
+++ b/src/TopogSettings.f90
@@ -252,7 +252,31 @@ contains
                      // " two 'Topog params' are needed for 'Type = USGS'; received " // Int2String(size(RunParams%TopogFuncParams)))
                end if
                TopogFunc => usgs
-            
+
+            case ('flume')
+                if (size(RunParams%TopogFuncParams) < 6) then
+                   call FatalErrorMessage("In the 'Topog' block in the input file " // &
+                      trim(RunParams%InputFile%s) // new_line('A') &
+                      // " six 'Topog params' are needed for 'Type = Flume'; received " // Int2String(size(RunParams%TopogFuncParams)))
+                end if
+                TopogFunc => flume
+
+            case ('channel power law')
+                if (size(RunParams%TopogFuncParams) < 3) then
+                   call FatalErrorMessage("In the 'Topog' block in the input file " // &
+                      trim(RunParams%InputFile%s) // new_line('A') &
+                      // " three 'Topog params' are needed for 'Type = Channel power law'; received " // Int2String(size(RunParams%TopogFuncParams)))
+                end if
+                TopogFunc => channel_powerlaw
+
+            case ('channel trapezium')
+                if (size(RunParams%TopogFuncParams) < 3) then
+                   call FatalErrorMessage("In the 'Topog' block in the input file " // &
+                      trim(RunParams%InputFile%s) // new_line('A') &
+                      // " three 'Topog params' are needed for 'Type = Channel trapezium'; received " // Int2String(size(RunParams%TopogFuncParams)))
+                end if
+                TopogFunc => channel_trapezium
+
             case ('xbislope')
                if (size(RunParams%TopogFuncParams) < 3) then
                   call FatalErrorMessage("In the 'Topog' block in the input file " // &
@@ -260,6 +284,14 @@ contains
                      // " three 'Topog params' are needed for 'Type = xbislope'; received " // Int2String(size(RunParams%TopogFuncParams)))
                end if
                TopogFunc => xbislope            
+
+            case ('xtrislope')
+               if (size(RunParams%TopogFuncParams) < 6) then
+                  call FatalErrorMessage("In the 'Topog' block in the input file " // &
+                     trim(RunParams%InputFile%s) // new_line('A') &
+                     // " six 'Topog params' are needed for 'Type = xtrislope'; received " // Int2String(size(RunParams%TopogFuncParams)))
+               end if
+               TopogFunc => xtrislope 
 
             case ('xsinslope')
                if (size(RunParams%TopogFuncParams) < 1) then

--- a/src/cversion.cpp
+++ b/src/cversion.cpp
@@ -1,0 +1,15 @@
+#include <string.h>
+
+// Define a default GIT_TAG if not provided
+#ifndef PACKAGE_VERSION
+#define PACKAGE_VERSION "Unknown"
+#endif
+
+extern "C" {
+    void get_version_tag_c(char* version, int* length)
+    {
+        const char* tag = PACKAGE_VERSION;
+        *length = strlen(tag);
+        strcpy(version, tag);
+    }
+}

--- a/src/main.f90
+++ b/src/main.f90
@@ -48,7 +48,9 @@ program Kestrel
    use restart_module, only: LoadInitialCondition
    use dem_module, only: LoadDEM
    use timestepper_module, only: Run
-   use output_module, only: CreateOutDir 
+   use output_module, only: CreateOutDir
+   use varstring_module, only: varString
+   use version_module, only: GetVersion 
 
    implicit none
 
@@ -59,6 +61,12 @@ program Kestrel
    ! Likewise, this contains all the data related to the numerical grid, 
    ! including the solution fields (see Grid.f90).
    type(GridType) :: grid
+
+   character(len=:), allocatable :: version
+
+   ! Set version
+   version = GetVersion()
+   RunParams%version = varString(trim(version))
 
    ! The following block indexes the fields that are explicitly stored during 
    ! the simulation. There are four primary flow variables (1-4). 
@@ -95,7 +103,7 @@ program Kestrel
    RunParams%nDimensions = 13
 
    write (stdout, *)
-   write (stdout, *) "Starting Kestrel."
+   write (stdout, *) "Starting Kestrel (" // RunParams%version%s // ")"
    write (stdout, *)
 
    ! Read input file and populate the type(RunSet) :: RunParams object

--- a/src/varStringClass.f90
+++ b/src/varStringClass.f90
@@ -189,6 +189,12 @@ module varstring_module
       procedure, pass(this) :: equal_varstring_right ! test equality of character string and varString
       generic, public :: operator(==) => equal_varstring, equal_varstring_left, equal_varstring_right ! Overload == comparison operator for varStrings
 
+      ! check non-equality (/=)
+      procedure, pass(this) :: not_equal_varstring ! test non-equality of  two varStrings
+      procedure, pass(this) :: not_equal_varstring_left ! test non-equality of varString and character string
+      procedure, pass(this) :: not_equal_varstring_right ! test non-equality of character string and varString
+      generic, public :: operator(/=) => not_equal_varstring, not_equal_varstring_left, not_equal_varstring_right ! Overload /= comparison operator for varStrings
+
       ! Methods:
 
       ! len [integer function]
@@ -407,6 +413,36 @@ contains
 
       isequal = (this%s == txt)
    end function equal_varstring_right
+
+   ! Private method to compare this varString with varString txt
+   !  notisequal = this /= txt
+   pure function not_equal_varstring(this, txt) result(isnotequal)
+      class(varString), intent(in) :: this
+      type(varString), intent(in) :: txt
+      logical isnotequal
+
+      isnotequal = (this%s /= txt%s)
+   end function not_equal_varstring
+
+   ! Private method to compare this varString with character string txt
+   !  notisequal = this /= txt
+   pure function not_equal_varstring_left(this, txt) result(notisequal)
+      class(varString), intent(in) :: this
+      character(len=*), intent(in) :: txt
+      logical notisequal
+
+      notisequal = (this%s /= txt)
+   end function not_equal_varstring_left
+
+   ! Private method to compare character string txt with this varString
+   !  isequal = this == txt
+   pure function not_equal_varstring_right(txt, this) result(isnotequal)
+      character(len=*), intent(in) :: txt
+      class(varString), intent(in) :: this
+      logical isnotequal
+
+      isnotequal = (this%s /= txt)
+   end function not_equal_varstring_right
 
    ! Determine the length of the string in this%s
    ! Called as N = this%len()

--- a/src/version.f90
+++ b/src/version.f90
@@ -1,0 +1,37 @@
+module version_module
+
+   use, intrinsic :: iso_c_binding, only: c_int, c_char
+
+   interface
+      subroutine get_version_tag(str, length) bind(C, name="get_version_tag_c")
+         import :: c_int, c_char
+         implicit none
+         character(kind=c_char), dimension(*), intent(out) :: str
+         integer(c_int), intent(out) :: length
+      end subroutine get_version_tag
+   end interface
+
+contains
+
+   function GetVersion() result(tag)
+      implicit none
+      character(len=:), allocatable :: tag
+      character(kind=c_char), dimension(:), allocatable :: str_buffer
+      integer(c_int) :: length
+
+      ! Allocate a buffer large enough to hold the C string
+      allocate(str_buffer(100))
+      
+      call get_version_tag(str_buffer, length)
+      if (length > 0) then
+         allocate(character(len=length) :: tag)
+         tag = transfer(str_buffer(1:length), tag)
+      else
+         tag = "Unknown"
+      end if
+
+      deallocate(str_buffer)
+      
+   end function GetVersion
+
+end module version_module

--- a/tests/runall.jl
+++ b/tests/runall.jl
@@ -147,9 +147,19 @@ function run_all()
       numpassed += run_netcdf()
    end
   
+   report_pass_rate_and_exit(numpassed, numtests)
+end
+
+function report_pass_rate_and_exit(numpassed, numtests)
    ratio = 100 * numpassed / numtests
    @printf "Results: %i/%i passed" numpassed numtests
    @printf "%s (%.1f%c)\n" (numpassed == numtests ? "!" : "") ratio '%'
+
+   if numpassed == numtests
+      exit()
+   else
+      exit(1)
+   end
 end
 
 # Print a list of available test categories.
@@ -192,11 +202,11 @@ else
    end
 
    if numtests >= 1
-      ratio = 100 * numpassed / numtests
-      @printf "Results: %i/%i passed" numpassed numtests
-      @printf "%s (%.1f%c)\n" (numpassed == numtests ? "!" : "") ratio '%'
+      report_pass_rate_and_exit(numpassed, numtests)
    else
       println("No valid tests selected.")
       print_options()
    end
 end
+
+exit(1) # default is to return error


### PR DESCRIPTION
Addresses #2

- Gets version from git tags in configure.ac, passed through -D flags in compilation, (clunky) read in cversion.cpp and passed to fortran version.f90.

- Version tag added to RunInfo.txt and netcdf files as a global attribute in Output.f90

- Version tag checked when reading files in Restart.f90 -- warning issued if stored version different from current installed Kestrel version.
