### PR TITLE
Get version from git tags, include in output, check in restart files.

### DIFF
--- a/.github/workflows/update_version_info.yml
+++ b/.github/workflows/update_version_info.yml
@@ -1,0 +1,51 @@
+name: Update version info on release
+
+on:
+  push:
+    tags:
+      - 'v*' # Trigger on version tags
+
+jobs:
+  update-headers:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Modify header comments and PACKAGE_VERSION
+        run: |
+          TAG_NAME=$(echo $GITHUB_REF | sed 's/refs\/tags\///')
+          # fortran files
+          for file in $(find . -name "*.f90"); do
+            sed -i "0,/^! Version .*/s//! Version $TAG_NAME/" $file
+          done
+          # c++ files
+          for file in $(find . -name "*.cpp" -o -name "*.h"); do
+            sed -i "0,/^\/\/ Version .*/s//\/\/ Version $TAG_NAME/" $file
+          done
+          # PACKAGE_VERSION
+          for file in $(find . -name "*.cpp" -o -name "*.h"); do
+            sed -i "s/\#define PACKAGE_VERSION .*/\#define PACKAGE_VERSION \"$TAG_NAME\"/" $file
+          done
+          # configure.ac
+          sed -i "s/m4_define(\[DEFAULT_VERSION\], .*/m4_define([DEFAULT_VERSION], [$TAG_NAME])/" configure.ac
+
+      - name: Commit changes and update tag
+        run: |
+          TAG_NAME=$(echo $GITHUB_REF | sed 's/refs\/tags\///')
+          git config --global user.name "update-version-info[bot]"
+          git config --global user.email "update-version-info[bot]@users.noreply.github.com"
+          git tag -d $TAG_NAME
+          git commit -a -m "Mark release $TAG_NAME"
+          git tag $TAG_NAME
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          force: true
+          tags: true
+

--- a/configure.ac
+++ b/configure.ac
@@ -1,3 +1,4 @@
+AC_PREREQ([2.68])
 AC_INIT([Kestrel], 
         [m4_esyscmd_s([git describe --tags])], 
         [Mark.Woodhouse@bristol.ac.uk, J.Langham@bristol.ac.uk])

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,6 @@
-AC_INIT([Kestrel], [1.0], [Mark.Woodhouse@bristol.ac.uk, J.Langham@bristol.ac.uk])
+AC_INIT([Kestrel], 
+        [m4_esyscmd_s([git describe --tags])], 
+        [Mark.Woodhouse@bristol.ac.uk, J.Langham@bristol.ac.uk])
 AC_CONFIG_SRCDIR([src/TimeStepper.f90])
 AC_CONFIG_MACRO_DIRS([m4])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,7 @@
 AC_PREREQ([2.68])
-AC_INIT([Kestrel], 
-        [m4_esyscmd_s([git describe --tags])], 
+m4_define([DEFAULT_VERSION], [v1.1.0])
+AC_INIT([Kestrel],
+        [m4_esyscmd_s([git --version > /dev/null 2>&1 && git describe --tags || echo DEFAULT_VERSION])],
         [Mark.Woodhouse@bristol.ac.uk, J.Langham@bristol.ac.uk])
 AC_CONFIG_SRCDIR([src/TimeStepper.f90])
 AC_CONFIG_MACRO_DIRS([m4])

--- a/src/Input.f90
+++ b/src/Input.f90
@@ -55,7 +55,7 @@ contains
 
       implicit none
 
-      type(RunSet), intent(out) :: RunParams
+      type(RunSet), intent(inout) :: RunParams
       logical :: FileExists
       integer :: stat ! Status of input/output
       type(varString) :: line

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,7 +19,7 @@ kestrel_SOURCES = cUTM.cpp RasterData.cpp SetPrecision.f90 \
 	SolverSettings.f90 OutputSettings.f90 TopogSettings.f90 Input.f90 Grid.f90 \
     Equations.f90 HydraulicRHS.f90 MorphodynamicRHS.f90 Redistribute.f90 \
     dem.f90 UpdateTiles.f90 SetSources.f90 NetCDFUtils.f90 \
-    Output.f90 Restart.f90 TimeStepper.f90 main.f90
+    Output.f90 Restart.f90 TimeStepper.f90 cversion.cpp version.f90 main.f90
 
 kestrel_FCFLAGS = -Wall -ffree-line-length-0 -fno-range-check -cpp $(NETCDF4_FFLAGS) $(AM_FCFLAGS) $(DEFS)
 kestrel_CXXFLAGS = -Wall $(GDAL_CFLAGS) $(PROJ_CFLAGS) $(AM_CXXFLAGS)

--- a/src/NetCDFUtils.f90
+++ b/src/NetCDFUtils.f90
@@ -87,7 +87,8 @@ module netcdf_utils_module
 
    interface get_nc_att
       module procedure :: get_nc_att_int, get_nc_att_real, &
-         get_nc_att_int_vec, get_nc_att_real_vec
+         get_nc_att_int_vec, get_nc_att_real_vec, &
+         get_nc_att_str
    end interface
 
 contains
@@ -887,6 +888,27 @@ contains
       val = real(nc_val, kind=wp)
       return
    end subroutine get_nc_att_real_vec
+
+   subroutine get_nc_att_str(ncid, att_name, val)
+    integer, intent(in) :: ncid
+    character(len=*), intent(in) :: att_name
+    character(len=:), allocatable, intent(out) :: val
+
+    integer :: nc_status
+    integer :: length
+
+    nc_status = nf90_inquire_attribute(ncid, NF90_GLOBAL, att_name, len=length)
+    if (nc_status /= NF90_NOERR) then
+        val = "Unknown"
+        return
+    end if
+
+    allocate(character(len=length) :: val)
+
+    nc_status = nf90_get_att(ncid, NF90_GLOBAL, att_name, val)
+    if (nc_status /= NF90_NOERR) call handle_err(nc_status, ' nf90_get_att '//att_name)
+    return
+ end subroutine get_nc_att_str
 
    subroutine handle_err(status, extra)
       integer, intent(in) :: status

--- a/src/Output.f90
+++ b/src/Output.f90
@@ -254,7 +254,8 @@ contains
 
       write (101, fmt="(a12,a4,a1,a2,a1,a2,a1,a4)") "# Run start = ", RunParams%RunDate%s(1:4), "-", RunParams%RunDate%s(5:6), &
          "-", RunParams%RunDate%s(7:8), " ", RunParams%RunTime%s(1:4)
-      write (101, fmt="(a18,a)") "# Input file name = ", RunParams%InputFile%s
+      write (101, fmt="(a20,a)") "# Kestrel version = ", RunParams%version%s
+      write (101, fmt="(a20,a)") "# Input file name = ", RunParams%InputFile%s
       write (101, *)
 
       write (101, fmt="(a)") "Domain:"
@@ -1032,7 +1033,8 @@ contains
       call put_nc_att(ncid, 'title', 'Kestrel: '//trim(filename))
       call put_nc_att(ncid, 'institution', 'University of Bristol')
       call put_nc_att(ncid, 'source', 'Kestrel')
-
+      call put_nc_att(ncid, 'version', RunParams%version%s)
+      
       call put_nc_att(ncid, 'Conventions', 'CF-1.11-draft')
       call put_nc_att(ncid, '_FillValue', -9999.9_wp)
 
@@ -1441,6 +1443,7 @@ contains
       call put_nc_att(ncid, 'title', 'Kestrel: Maximums')
       call put_nc_att(ncid, 'institution', 'University of Bristol')
       call put_nc_att(ncid, 'source', 'Kestrel')
+      call put_nc_att(ncid, 'version', RunParams%version%s)
 
       call put_nc_att(ncid, 'Conventions', 'CF-1.11-draft')
       call put_nc_att(ncid, '_FillValue', -9999.9_wp)

--- a/src/RunSettings.f90
+++ b/src/RunSettings.f90
@@ -159,6 +159,8 @@ module runsettings_module
    ! the simulation. It is subdivided into sections which each have their own
    ! module for initialisation in the files *Settings.f90 and Parameters.f90. 
    type RunSet
+   ! -- Version --
+      type(varString) :: version
 
    ! -- Domain settings. --
 

--- a/src/cversion.cpp
+++ b/src/cversion.cpp
@@ -1,3 +1,23 @@
+// This file is part of the Kestrel software for simulations
+// of sediment-laden Earth surface flows.
+//
+// Version 1.0
+//
+// Copyright 2023 Mark J. Woodhouse, Jake Langham, (University of Bristol).
+//
+// This program is free software: you can redistribute it and/or modify it 
+// under the terms of the GNU General Public License as published by the Free 
+// Software Foundation, either version 3 of the License, or (at your option) 
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT 
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for 
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with 
+// this program. If not, see <https://www.gnu.org/licenses/>. 
+
 #include <string.h>
 
 // Define a default GIT_TAG if not provided

--- a/src/cversion.cpp
+++ b/src/cversion.cpp
@@ -1,0 +1,15 @@
+#include <string.h>
+
+// Define a default GIT_TAG if not provided
+#ifndef PACKAGE_VERSION
+#define PACKAGE_VERSION "Unknown"
+#endif
+
+extern "C" {
+    void get_version_tag_c(char* version, int* length)
+    {
+        const char* tag = PACKAGE_VERSION;
+        *length = strlen(tag);
+        strcpy(version, tag);
+    }
+}

--- a/src/main.f90
+++ b/src/main.f90
@@ -48,7 +48,9 @@ program Kestrel
    use restart_module, only: LoadInitialCondition
    use dem_module, only: LoadDEM
    use timestepper_module, only: Run
-   use output_module, only: CreateOutDir 
+   use output_module, only: CreateOutDir
+   use varstring_module, only: varString
+   use version_module, only: GetVersion 
 
    implicit none
 
@@ -59,6 +61,12 @@ program Kestrel
    ! Likewise, this contains all the data related to the numerical grid, 
    ! including the solution fields (see Grid.f90).
    type(GridType) :: grid
+
+   character(len=:), allocatable :: version
+
+   ! Set version
+   version = GetVersion()
+   RunParams%version = varString(trim(version))
 
    ! The following block indexes the fields that are explicitly stored during 
    ! the simulation. There are four primary flow variables (1-4). 
@@ -95,7 +103,7 @@ program Kestrel
    RunParams%nDimensions = 13
 
    write (stdout, *)
-   write (stdout, *) "Starting Kestrel."
+   write (stdout, *) "Starting Kestrel (" // RunParams%version%s // ")"
    write (stdout, *)
 
    ! Read input file and populate the type(RunSet) :: RunParams object

--- a/src/varStringClass.f90
+++ b/src/varStringClass.f90
@@ -189,6 +189,12 @@ module varstring_module
       procedure, pass(this) :: equal_varstring_right ! test equality of character string and varString
       generic, public :: operator(==) => equal_varstring, equal_varstring_left, equal_varstring_right ! Overload == comparison operator for varStrings
 
+      ! check non-equality (/=)
+      procedure, pass(this) :: not_equal_varstring ! test non-equality of  two varStrings
+      procedure, pass(this) :: not_equal_varstring_left ! test non-equality of varString and character string
+      procedure, pass(this) :: not_equal_varstring_right ! test non-equality of character string and varString
+      generic, public :: operator(/=) => not_equal_varstring, not_equal_varstring_left, not_equal_varstring_right ! Overload /= comparison operator for varStrings
+
       ! Methods:
 
       ! len [integer function]
@@ -407,6 +413,36 @@ contains
 
       isequal = (this%s == txt)
    end function equal_varstring_right
+
+   ! Private method to compare this varString with varString txt
+   !  notisequal = this /= txt
+   pure function not_equal_varstring(this, txt) result(isnotequal)
+      class(varString), intent(in) :: this
+      type(varString), intent(in) :: txt
+      logical isnotequal
+
+      isnotequal = (this%s /= txt%s)
+   end function not_equal_varstring
+
+   ! Private method to compare this varString with character string txt
+   !  notisequal = this /= txt
+   pure function not_equal_varstring_left(this, txt) result(notisequal)
+      class(varString), intent(in) :: this
+      character(len=*), intent(in) :: txt
+      logical notisequal
+
+      notisequal = (this%s /= txt)
+   end function not_equal_varstring_left
+
+   ! Private method to compare character string txt with this varString
+   !  isequal = this == txt
+   pure function not_equal_varstring_right(txt, this) result(isnotequal)
+      character(len=*), intent(in) :: txt
+      class(varString), intent(in) :: this
+      logical isnotequal
+
+      isnotequal = (this%s /= txt)
+   end function not_equal_varstring_right
 
    ! Determine the length of the string in this%s
    ! Called as N = this%len()

--- a/src/version.f90
+++ b/src/version.f90
@@ -1,3 +1,23 @@
+! This file is part of the Kestrel software for simulations
+! of sediment-laden Earth surface flows.
+!
+! Version 1.0
+!
+! Copyright 2023 Mark J. Woodhouse, Jake Langham, (University of Bristol).
+!
+! This program is free software: you can redistribute it and/or modify it 
+! under the terms of the GNU General Public License as published by the Free 
+! Software Foundation, either version 3 of the License, or (at your option) 
+! any later version.
+!
+! This program is distributed in the hope that it will be useful, but WITHOUT 
+! ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+! FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for 
+! more details.
+!
+! You should have received a copy of the GNU General Public License along with 
+! this program. If not, see <https://www.gnu.org/licenses/>. 
+
 module version_module
 
    use, intrinsic :: iso_c_binding, only: c_int, c_char

--- a/src/version.f90
+++ b/src/version.f90
@@ -1,0 +1,37 @@
+module version_module
+
+   use, intrinsic :: iso_c_binding, only: c_int, c_char
+
+   interface
+      subroutine get_version_tag(str, length) bind(C, name="get_version_tag_c")
+         import :: c_int, c_char
+         implicit none
+         character(kind=c_char), dimension(*), intent(out) :: str
+         integer(c_int), intent(out) :: length
+      end subroutine get_version_tag
+   end interface
+
+contains
+
+   function GetVersion() result(tag)
+      implicit none
+      character(len=:), allocatable :: tag
+      character(kind=c_char), dimension(:), allocatable :: str_buffer
+      integer(c_int) :: length
+
+      ! Allocate a buffer large enough to hold the C string
+      allocate(str_buffer(100))
+      
+      call get_version_tag(str_buffer, length)
+      if (length > 0) then
+         allocate(character(len=length) :: tag)
+         tag = transfer(str_buffer(1:length), tag)
+      else
+         tag = "Unknown"
+      end if
+
+      deallocate(str_buffer)
+      
+   end function GetVersion
+
+end module version_module


### PR DESCRIPTION
Addresses #2 

    Gets version from git tags in configure.ac, passed through -D flags in compilation, (clunky) read in cversion.cpp and passed to fortran version.f90.

    Version tag added to RunInfo.txt and netcdf files as a global attribute in Output.f90

    Version tag checked when reading files in Restart.f90 -- warning issued if stored version different from current installed Kestrel version.