### PR TITLE
Enable support for ppc64le architecture build by setting correct Fortran compiler flags.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,19 @@ AC_ARG_ENABLE([debug],
 esac],[debug=false])
 AM_CONDITIONAL([DEBUG], [test x$debug = xtrue])
 
+# Detect architecture to set Fortran compile flags in Makefile
+AS_VAR_SET([ARCH], [`uname -m`])
+case "$ARCH" in
+  ppc64le)
+    FC_ARCH_FLAGS="-mcpu=native -mtune=native"
+    ;;
+  *)
+    FC_ARCH_FLAGS="-march=native -mtune=native"
+    ;;
+esac
+
+AC_SUBST([FC_ARCH_FLAGS])
+
 AC_CONFIG_FILES([
  Makefile
  src/Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,8 +4,8 @@ AM_CXXFLAGS = -g
 else
 AM_FCFLAGS = -O2 -falign-loops=16
 if LINUX
-# These optimisation flags are only supported by gcc on linux.
-AM_FCFLAGS += -march=native -mtune=native
+# Set architecture-specific optimisation flags from configure
+AM_FCFLAGS += @ARCH_FLAGS@
 endif
 AM_CXXFLAGS = -O2 -falign-loops=16 
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,7 +5,7 @@ else
 AM_FCFLAGS = -O2 -falign-loops=16
 if LINUX
 # Set architecture-specific optimisation flags from configure
-AM_FCFLAGS += @ARCH_FLAGS@
+AM_FCFLAGS += @FC_ARCH_FLAGS@
 endif
 AM_CXXFLAGS = -O2 -falign-loops=16 
 endif


### PR DESCRIPTION
**Background:**
Issue ref - https://github.com.mcas.ms/jakelangham/kestrel/issues/40

When building Kestrel on Power (ppc64le) architecture, the existing Makefile uses the compiler flag **-march=native** for Fortran compilation. However, on ppc64le with gfortran, this flag is not supported and causes build failures:

Error:
```
gfortran: error: unrecognized command-line option '-march=native'; did you mean '-mcpu=native'?
make[1]: *** [Makefile:573: kestrel-SetPrecision.o] Error 1
make[1]: Leaving directory '/kestrel/src'
make: *** [Makefile:383: all-recursive] Error 1
```

Fix:
- Updated configure.ac to detect the architecture at configuration time using the `uname -m` linux command.
- For ppc64le, set the Fortran compiler flag to `-mcpu=native`
- For other architectures, continue using` -march=native`
- Updated Makefile.am to append @FC_ARCH_FLAGS@ to AM_FCFLAGS under the LINUX condition, ensuring architecture-specific optimization flags are correctly applied.
- This change maintains existing behavior for x86 and other supported platforms while fixing build issues on ppc64le arch.